### PR TITLE
Security Audit

### DIFF
--- a/content/blog/cl-macros/index.md
+++ b/content/blog/cl-macros/index.md
@@ -240,12 +240,12 @@ It is slightly more verbose, but arguably more readable. To convince you that th
                                 :data nil)
       (tagbody
        sb-loop::next-loop
-         (when (> k '10) (go sb-loop::end-loop))
-         (setq #:loop-sum-641 (+ #:loop-sum-641 (expt k 2)))
-         (sb-loop::loop-desetq k (1+ k))
-         (go sb-loop::next-loop)
+        (when (> k '10) (go sb-loop::end-loop))
+        (setq #:loop-sum-641 (+ #:loop-sum-641 (expt k 2)))
+        (sb-loop::loop-desetq k (1+ k))
+        (go sb-loop::next-loop)
        sb-loop::end-loop
-         (return-from nil #:loop-sum-641)))))
+        (return-from nil #:loop-sum-641)))))
 ```
 
 `loop` is designed to generate fast code at the expense of human readability, hence the somewhat messy code above. This is usually not a problem since `loop` has been extensively tested and debugged, and its expansion is never directly seen in source code (remember that the compiler transparently performs macro expansion for you). The only time you may need to look at a macro's expansion after it's first written, is when you need to debug it.
@@ -265,12 +265,14 @@ Notice how it seamlessly combines regular Common Lisp with `loop`'s specific syn
 ```lisp
 ;; https://en.wikipedia.org/wiki/Collatz_conjecture
 (defun collatz (n)
-  (loop for i = 0 then (1+ i)
-        while (not (= 1 n))
-        do (if (evenp n)
-               (setf n (/ n 2))
-               (setf n (1+ (* 3 n))))
-        finally (return i)))
+  (loop
+    for i = 0 then (1+ i)
+    while (not (= 1 n))
+    do
+       (if (evenp n)
+           (setf n (/ n 2))
+           (setf n (1+ (* 3 n))))
+    finally (return i)))
 ```
 
 ```lisp

--- a/content/blog/cl-macros/index.md
+++ b/content/blog/cl-macros/index.md
@@ -240,12 +240,12 @@ It is slightly more verbose, but arguably more readable. To convince you that th
                                 :data nil)
       (tagbody
        sb-loop::next-loop
-        (when (> k '10) (go sb-loop::end-loop))
-        (setq #:loop-sum-641 (+ #:loop-sum-641 (expt k 2)))
-        (sb-loop::loop-desetq k (1+ k))
-        (go sb-loop::next-loop)
+         (when (> k '10) (go sb-loop::end-loop))
+         (setq #:loop-sum-641 (+ #:loop-sum-641 (expt k 2)))
+         (sb-loop::loop-desetq k (1+ k))
+         (go sb-loop::next-loop)
        sb-loop::end-loop
-        (return-from nil #:loop-sum-641)))))
+         (return-from nil #:loop-sum-641)))))
 ```
 
 `loop` is designed to generate fast code at the expense of human readability, hence the somewhat messy code above. This is usually not a problem since `loop` has been extensively tested and debugged, and its expansion is never directly seen in source code (remember that the compiler transparently performs macro expansion for you). The only time you may need to look at a macro's expansion after it's first written, is when you need to debug it.
@@ -265,14 +265,12 @@ Notice how it seamlessly combines regular Common Lisp with `loop`'s specific syn
 ```lisp
 ;; https://en.wikipedia.org/wiki/Collatz_conjecture
 (defun collatz (n)
-  (loop
-    for i = 0 then (1+ i)
-    while (not (= 1 n))
-    do
-       (if (evenp n)
-           (setf n (/ n 2))
-           (setf n (1+ (* 3 n))))
-    finally (return i)))
+  (loop for i = 0 then (1+ i)
+        while (not (= 1 n))
+        do (if (evenp n)
+               (setf n (/ n 2))
+               (setf n (1+ (* 3 n))))
+        finally (return i)))
 ```
 
 ```lisp

--- a/content/blog/clean-code-critique/index.md
+++ b/content/blog/clean-code-critique/index.md
@@ -31,57 +31,57 @@ The code in question is a program to generate a list of prime numbers (it is wri
 
 ```java
 public class PrintPrimes {
-  public static void main(String[] args) {
-    final int M = 1000;
-    final int RR = 50;
-    final int CC = 4;
-    final int WW = 10;
-    final int ORDMAX = 30;
-    int P[] = new int[M + 1];
-    int PAGENUMBER, PAGEOFFSET, ROWOFFSET;
-    int C, J, K;
-    boolean JPRIME;
-    int ORD, SQUARE, N;
-    int MULT[] = new int[ORDMAX + 1];
-    J = 1;
-    K = 1; P[1] = 2; ORD = 2; SQUARE = 9;
-    while (K < M) {
-      do {
-        J = J + 2;
-        if (J == SQUARE) {
-          ORD = ORD + 1;
-          SQUARE = P[ORD] * P[ORD];
-          MULT[ORD - 1] = J;
-        }
-        N = 2;
-        JPRIME = true;
-        while (N < ORD && JPRIME) {
-          while (MULT[N] < J)
-            MULT[N] = MULT[N] + P[N] + P[N];
-          if (MULT[N] == J)
-            JPRIME = false;
-          N = N + 1;
-        }
-      } while (!JPRIME);
-      K = K + 1;
-      P[K] = J;
-    }
-    PAGENUMBER = 1;
-    PAGEOFFSET = 1;
-    while (PAGEOFFSET <= M) {
-      System.out.println("The Prime Numbers --- Page " + PAGENUMBER);
-      System.out.println("");
-      for (ROWOFFSET = PAGEOFFSET; ROWOFFSET < PAGEOFFSET + RR; ROWOFFSET++) {
-        for (C = 0; C < CC;C++)
-          if (ROWOFFSET + C * RR <= M)
-            System.out.format("%10d", P[ROWOFFSET + C * RR]);
-            System.out.println("");
+   public static void main(String[] args) {
+      final int M = 1000;
+      final int RR = 50;
+      final int CC = 4;
+      final int WW = 10;
+      final int ORDMAX = 30;
+      int P[] = new int[M + 1];
+      int PAGENUMBER, PAGEOFFSET, ROWOFFSET;
+      int C, J, K;
+      boolean JPRIME;
+      int ORD, SQUARE, N;
+      int MULT[] = new int[ORDMAX + 1];
+      J = 1;
+      K = 1; P[1] = 2; ORD = 2; SQUARE = 9;
+      while (K < M) {
+         do {
+            J = J + 2;
+            if (J == SQUARE) {
+               ORD = ORD + 1;
+               SQUARE = P[ORD] * P[ORD];
+               MULT[ORD - 1] = J;
+            }
+            N = 2;
+            JPRIME = true;
+            while (N < ORD && JPRIME) {
+               while (MULT[N] < J)
+                  MULT[N] = MULT[N] + P[N] + P[N];
+               if (MULT[N] == J)
+                  JPRIME = false;
+               N = N + 1;
+            }
+         } while (!JPRIME);
+         K = K + 1;
+         P[K] = J;
       }
-      System.out.println("\f");
-      PAGENUMBER = PAGENUMBER + 1;
-      PAGEOFFSET = PAGEOFFSET + RR * CC;
-    }
-  }
+      PAGENUMBER = 1;
+      PAGEOFFSET = 1;
+      while (PAGEOFFSET <= M) {
+         System.out.println("The Prime Numbers --- Page " + PAGENUMBER);
+         System.out.println("");
+         for (ROWOFFSET = PAGEOFFSET; ROWOFFSET < PAGEOFFSET + RR; ROWOFFSET++) {
+            for (C = 0; C < CC;C++)
+               if (ROWOFFSET + C * RR <= M)
+                  System.out.format("%10d", P[ROWOFFSET + C * RR]);
+                  System.out.println("");
+         }
+         System.out.println("\f");
+         PAGENUMBER = PAGENUMBER + 1;
+         PAGEOFFSET = PAGEOFFSET + RR * CC;
+      }
+   }
 
 ```
 
@@ -89,18 +89,18 @@ And here's the proposed refactoring in the book:
 
 ```java
 public class PrimePrinter {
-  public static void main(String[] args) {
-    final int NUMBER_OF_PRIMES = 1000;
-    int[] primes = PrimeGenerator.generate(NUMBER_OF_PRIMES);
+   public static void main(String[] args) {
+      final int NUMBER_OF_PRIMES = 1000;
+      int[] primes = PrimeGenerator.generate(NUMBER_OF_PRIMES);
 
-    final int ROWS_PER_PAGE = 50;
-    final int COLUMNS_PER_PAGE = 4;
-    RowColumnPagePrinter tablePrinter =
-      new RowColumnPagePrinter(
-        ROWS_PER_PAGE, COLUMNS_PER_PAGE,
-        "The First " + NUMBER_OF_PRIMES + " Prime Numbers");
-    tablePrinter.print(primes);
-  }
+      final int ROWS_PER_PAGE = 50;
+      final int COLUMNS_PER_PAGE = 4;
+      RowColumnPagePrinter tablePrinter =
+         new RowColumnPagePrinter(
+            ROWS_PER_PAGE, COLUMNS_PER_PAGE,
+            "The First " + NUMBER_OF_PRIMES + " Prime Numbers");
+      tablePrinter.print(primes);
+   }
 }
 ```
 
@@ -110,50 +110,50 @@ Let's have a look at the `RowColumnPagePrinter` class:
 
 ```java
 public class RowColumnPagePrinter {
-  private int rowsPerPage;
-  private int columnsPerPage;
-  private int numbersPerPage;
-  private String pageHeader;
-  private PrintStream printStream;
+   private int rowsPerPage;
+   private int columnsPerPage;
+   private int numbersPerPage;
+   private String pageHeader;
+   private PrintStream printStream;
 
-  public RowColumnPagePrinter(int rowsPerPage, int columnsPerPage, String pageHeader) {
-    this.rowsPerPage = rowsPerPage;
-    this.columnsPerPage = columnsPerPage;
-    this.pageHeader = pageHeader;
-    this.numbersPerPage = rowsPerPage * columnsPerPage;
-    this.printStream = System.out;
-  }
-  public void print(int data[]) {
-    int pageNumber = 1;
-    for (int firstIndexOnPage = 0; // highlight-line
-       firstIndexOnPage < data.length; // highlight-line
-       firstIndexOnPage += numbersPerPage) { // highlight-line
-      int lastIndexOnPage = Math.min(firstIndexOnPage + numbersPerPage - 1, data.length - 1);
-      printPageHeader(pageHeader, pageNumber);
-      printPage(firstIndexOnPage, lastIndexOnPage, data);
-      printStream.println("\f");
-      pageNumber++;
-    }
-  }
-  private void printPage(int firstIndexOnPage, int lastIndexOnPage, int[] data) {
-    int firstIndexOfLastRowOnPage = firstIndexOnPage + rowsPerPage - 1;
-    for (int firstIndexInRow = firstIndexOnPage; // highlight-line
-       firstIndexInRow <= firstIndexOfLastRowOnPage; // highlight-line
-       firstIndexInRow++) { // highlight-line
-      printRow(firstIndexInRow, lastIndexOnPage, data);
+   public RowColumnPagePrinter(int rowsPerPage, int columnsPerPage, String pageHeader) {
+      this.rowsPerPage = rowsPerPage;
+      this.columnsPerPage = columnsPerPage;
+      this.pageHeader = pageHeader;
+      this.numbersPerPage = rowsPerPage * columnsPerPage;
+      this.printStream = System.out;
+   }
+   public void print(int data[]) {
+      int pageNumber = 1;
+      for (int firstIndexOnPage = 0; // highlight-line
+          firstIndexOnPage < data.length; // highlight-line
+          firstIndexOnPage += numbersPerPage) { // highlight-line
+         int lastIndexOnPage = Math.min(firstIndexOnPage + numbersPerPage - 1, data.length - 1);
+         printPageHeader(pageHeader, pageNumber);
+         printPage(firstIndexOnPage, lastIndexOnPage, data);
+         printStream.println("\f");
+         pageNumber++;
+      }
+   }
+   private void printPage(int firstIndexOnPage, int lastIndexOnPage, int[] data) {
+      int firstIndexOfLastRowOnPage = firstIndexOnPage + rowsPerPage - 1;
+      for (int firstIndexInRow = firstIndexOnPage; // highlight-line
+          firstIndexInRow <= firstIndexOfLastRowOnPage; // highlight-line
+          firstIndexInRow++) { // highlight-line
+         printRow(firstIndexInRow, lastIndexOnPage, data);
+         printStream.println("");
+      }
+   }
+   private void printRow(int firstIndexInRow, int lastIndexOnPage, int[] data) {
+      for (int column = 0; column < columnsPerPage; column++) {
+         int index = firstIndexInRow + column * rowsPerPage;
+         if (index <= lastIndexOnPage)
+            printStream.format("%10d", data[index]); }
+   }
+   private void printPageHeader(String pageHeader, int pageNumber) {
+      printStream.println(pageHeader + " --- Page " + pageNumber);
       printStream.println("");
-    }
-  }
-  private void printRow(int firstIndexInRow, int lastIndexOnPage, int[] data) {
-    for (int column = 0; column < columnsPerPage; column++) {
-      int index = firstIndexInRow + column * rowsPerPage;
-      if (index <= lastIndexOnPage)
-        printStream.format("%10d", data[index]); }
-  }
-  private void printPageHeader(String pageHeader, int pageNumber) {
-    printStream.println(pageHeader + " --- Page " + pageNumber);
-    printStream.println("");
-  }
+   }
 }
 ```
 
@@ -169,56 +169,56 @@ Go ahead and spend some minutes trying to understand it before reading on.
 
 ```java
 public class PrimeGenerator {
-  private static int[] primes;
-  private static ArrayList<Integer> multiplesOfPrimeFactors;
+   private static int[] primes;
+   private static ArrayList<Integer> multiplesOfPrimeFactors;
 
-  public static int[] generate(int n) {
-    primes = new int[n];
-    multiplesOfPrimeFactors = new ArrayList<Integer>();
-    set2AsFirstPrime();
-    checkOddNumbersForSubsequentPrimes();
-    return primes;
-  }
-  static void set2AsFirstPrime() {
-    primes[0] = 2;
-    multiplesOfPrimeFactors.add(2);
-  }
-  static void checkOddNumbersForSubsequentPrimes() {
-    int primeIndex = 1;
-    for (int candidate = 3; primeIndex < primes.length; candidate += 2) {
-      if (isPrime(candidate))
-        primes[primeIndex++] = candidate;
-    }
-  }
-  static boolean isPrime(int candidate) {
-    if (isLeastRelevantMultipleOfNextLargerPrimeFactor(candidate)) {
-      multiplesOfPrimeFactors.add(candidate);
-      return false;
-    }
-    return isNotMultipleOfAnyPreviousPrimeFactor(candidate);
-  }
-  static boolean isLeastRelevantMultipleOfNextLargerPrimeFactor(int candidate) {
-    int nextLargerPrimeFactor = primes[multiplesOfPrimeFactors.size()];
-    int leastRelevantMultiple = nextLargerPrimeFactor * nextLargerPrimeFactor;
-    return candidate == leastRelevantMultiple;
-  }
-  static boolean isNotMultipleOfAnyPreviousPrimeFactor(int candidate) {
-    for (int n = 1; n < multiplesOfPrimeFactors.size(); n++) {
-      if (isMultipleOfNthPrimeFactor(candidate, n))
-        return false;
-    }
-    return true;
-  }
-  static boolean isMultipleOfNthPrimeFactor(int candidate, int n) {
-    return candidate == smallestOddNthMultipleNotLessThanCandidate(candidate, n);
-  }
-  static int smallestOddNthMultipleNotLessThanCandidate(int candidate, int n) {
-    int multiple = multiplesOfPrimeFactors.get(n);
-    while (multiple < candidate)
-      multiple += 2 * primes[n];
-    multiplesOfPrimeFactors.set(n, multiple);
-    return multiple;
-  }
+   public static int[] generate(int n) {
+      primes = new int[n];
+      multiplesOfPrimeFactors = new ArrayList<Integer>();
+      set2AsFirstPrime();
+      checkOddNumbersForSubsequentPrimes();
+      return primes;
+   }
+   static void set2AsFirstPrime() {
+      primes[0] = 2;
+      multiplesOfPrimeFactors.add(2);
+   }
+   static void checkOddNumbersForSubsequentPrimes() {
+      int primeIndex = 1;
+      for (int candidate = 3; primeIndex < primes.length; candidate += 2) {
+         if (isPrime(candidate))
+            primes[primeIndex++] = candidate;
+      }
+   }
+   static boolean isPrime(int candidate) {
+      if (isLeastRelevantMultipleOfNextLargerPrimeFactor(candidate)) {
+         multiplesOfPrimeFactors.add(candidate);
+         return false;
+      }
+      return isNotMultipleOfAnyPreviousPrimeFactor(candidate);
+   }
+   static boolean isLeastRelevantMultipleOfNextLargerPrimeFactor(int candidate) {
+      int nextLargerPrimeFactor = primes[multiplesOfPrimeFactors.size()];
+      int leastRelevantMultiple = nextLargerPrimeFactor * nextLargerPrimeFactor;
+      return candidate == leastRelevantMultiple;
+   }
+   static boolean isNotMultipleOfAnyPreviousPrimeFactor(int candidate) {
+      for (int n = 1; n < multiplesOfPrimeFactors.size(); n++) {
+         if (isMultipleOfNthPrimeFactor(candidate, n))
+            return false;
+      }
+      return true;
+   }
+   static boolean isMultipleOfNthPrimeFactor(int candidate, int n) {
+      return candidate == smallestOddNthMultipleNotLessThanCandidate(candidate, n);
+   }
+   static int smallestOddNthMultipleNotLessThanCandidate(int candidate, int n) {
+      int multiple = multiplesOfPrimeFactors.get(n);
+      while (multiple < candidate)
+         multiple += 2 * primes[n];
+      multiplesOfPrimeFactors.set(n, multiple);
+      return multiple;
+   }
 }
 ```
 
@@ -228,28 +228,28 @@ If we take the idea of "writing short functions that do one thing" quite literal
 
 ```java
 public class PrimeGenerator {
-  private static int[] primes;
-  private static ArrayList<Integer> multiplesOfPrimeFactors;
+   private static int[] primes;
+   private static ArrayList<Integer> multiplesOfPrimeFactors;
 
-  static int[] generate(int n) {
-    primes = new int[n];
-    multiplesOfPrimeFactors = new ArrayList<Integer>();
-    set2AsFirstPrime();
-    checkOddNumbersForSubsequentPrimes();
-    return primes;
-  }
-  static void set2AsFirstPrime() {
-    primes[0] = 2;
-    multiplesOfPrimeFactors.add(2);
-  }
-  static void checkOddNumbersForSubsequentPrimes() {
-    int primeIndex = 1;
-    for (int candidate = 3; primeIndex < primes.length; candidate += 2) {
-      if (isPrime(candidate))
-        primes[primeIndex++] = candidate;
-    }
-  }
-  // ...
+   static int[] generate(int n) {
+      primes = new int[n];
+      multiplesOfPrimeFactors = new ArrayList<Integer>();
+      set2AsFirstPrime();
+      checkOddNumbersForSubsequentPrimes();
+      return primes;
+   }
+   static void set2AsFirstPrime() {
+      primes[0] = 2;
+      multiplesOfPrimeFactors.add(2);
+   }
+   static void checkOddNumbersForSubsequentPrimes() {
+      int primeIndex = 1;
+      for (int candidate = 3; primeIndex < primes.length; candidate += 2) {
+         if (isPrime(candidate))
+            primes[primeIndex++] = candidate;
+      }
+   }
+   // ...
  }
 ```
 
@@ -257,15 +257,15 @@ These first few methods contain simple logic, but it's not obvious _why_ they're
 
 ```java
 public class PrimeGenerator {
-  // ...
-  static boolean isPrime(int candidate) {
-    if (isLeastRelevantMultipleOfNextLargerPrimeFactor(candidate)) { // highlight-line
-      multiplesOfPrimeFactors.add(candidate); // highlight-line
-      return false; // highlight-line
-    }
-    return isNotMultipleOfAnyPreviousPrimeFactor(candidate);
-  }
-  // ...
+   // ...
+   static boolean isPrime(int candidate) {
+      if (isLeastRelevantMultipleOfNextLargerPrimeFactor(candidate)) { // highlight-line
+         multiplesOfPrimeFactors.add(candidate); // highlight-line
+         return false; // highlight-line
+      }
+      return isNotMultipleOfAnyPreviousPrimeFactor(candidate);
+   }
+   // ...
 }
 ```
 
@@ -278,13 +278,13 @@ It seems like the author is hoping that the code will explain itself, but unfort
 
 ```java
 public class PrimeGenerator {
-  // ...
-  static boolean isLeastRelevantMultipleOfNextLargerPrimeFactor(int candidate) {
-    int nextLargerPrimeFactor = primes[multiplesOfPrimeFactors.size()];
-    int leastRelevantMultiple = nextLargerPrimeFactor * nextLargerPrimeFactor;
-    return candidate == leastRelevantMultiple;
-  }
-  // ...
+   // ...
+   static boolean isLeastRelevantMultipleOfNextLargerPrimeFactor(int candidate) {
+      int nextLargerPrimeFactor = primes[multiplesOfPrimeFactors.size()];
+      int leastRelevantMultiple = nextLargerPrimeFactor * nextLargerPrimeFactor;
+      return candidate == leastRelevantMultiple;
+   }
+   // ...
 }
 ```
 
@@ -294,15 +294,15 @@ The next method is straightforward and follows the [principle of least astonishm
 
 ```java
 public class PrimeGenerator {
-  // ...
-  static boolean isNotMultipleOfAnyPreviousPrimeFactor(int candidate) {
-    for (int n = 1; n < multiplesOfPrimeFactors.size(); n++) {
-      if (isMultipleOfNthPrimeFactor(candidate, n))
-        return false;
-    }
-    return true;
-  }
-  // ...
+   // ...
+   static boolean isNotMultipleOfAnyPreviousPrimeFactor(int candidate) {
+      for (int n = 1; n < multiplesOfPrimeFactors.size(); n++) {
+         if (isMultipleOfNthPrimeFactor(candidate, n))
+            return false;
+      }
+      return true;
+   }
+   // ...
 }
 ```
 
@@ -310,18 +310,18 @@ Unfortunately, the last two methods seem like they could have been just one, and
 
 ```java
 public class PrimeGenerator {
-  // ...
-  static boolean isMultipleOfNthPrimeFactor(int candidate, int n) {
-    return candidate == smallestOddNthMultipleNotLessThanCandidate(candidate, n);
-  }
-  static int smallestOddNthMultipleNotLessThanCandidate(int candidate, int n) {
-    int multiple = multiplesOfPrimeFactors.get(n);
-    while (multiple < candidate)
-      multiple += 2 * primes[n];
-    multiplesOfPrimeFactors.set(n, multiple);
-    return multiple;
-  }
-  // ...
+   // ...
+   static boolean isMultipleOfNthPrimeFactor(int candidate, int n) {
+      return candidate == smallestOddNthMultipleNotLessThanCandidate(candidate, n);
+   }
+   static int smallestOddNthMultipleNotLessThanCandidate(int candidate, int n) {
+      int multiple = multiplesOfPrimeFactors.get(n);
+      while (multiple < candidate)
+         multiple += 2 * primes[n];
+      multiplesOfPrimeFactors.set(n, multiple);
+      return multiple;
+   }
+   // ...
 }
 ```
 
@@ -350,66 +350,66 @@ After studying the code, the underlying algorithm (the [sieve of Eratosthenes](h
 ```python
 # TODO: review whether the optimizations are truly worth the additional complexity
 class PrimeGenerator:
-  """
-  Generates a list of the first `n` primes using the "sieve of Eratosthenes"
-  algorithm (https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes) with some
-  optimizations:
+   """
+   Generates a list of the first `n` primes using the "sieve of Eratosthenes"
+   algorithm (https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes) with some
+   optimizations:
 
-  1. Instead of testing `candidate % prime == 0`, we use repeated sums:
-     `prime + ... + remainder == candidate` (where `remainder` is zero if
-     `candidate % prime == 0` is true).
-     Hence `prime_multiples[i] == k*prime[i]` always holds for some `k`
+   1. Instead of testing `candidate % prime == 0`, we use repeated sums:
+       `prime + ... + remainder == candidate` (where `remainder` is zero if
+       `candidate % prime == 0` is true).
+       Hence `prime_multiples[i] == k*prime[i]` always holds for some `k`
 
-  2. We start testing divisibility by `prime` at `prime^2` because
-     smaller multiples will have already been considered by tests with
-     smaller primes. Hence the phrase "relevant multiple" in the method
-     `add_next_relevant_prime_multiple_if_needed`
-  """
-  def generate(self, n):
-    self.primes = [2, 3]
-    self.prime_multiples = [2**2, 3**2]
+   2. We start testing divisibility by `prime` at `prime^2` because
+       smaller multiples will have already been considered by tests with
+       smaller primes. Hence the phrase "relevant multiple" in the method
+       `add_next_relevant_prime_multiple_if_needed`
+   """
+   def generate(self, n):
+      self.primes = [2, 3]
+      self.prime_multiples = [2**2, 3**2]
 
-    prime = 3
-    for _ in range(n):
-      prime = self._find_next_prime(prime)
-      self.primes.append(prime)
-    return self.primes
+      prime = 3
+      for _ in range(n):
+         prime = self._find_next_prime(prime)
+         self.primes.append(prime)
+      return self.primes
 
-  def _find_next_prime(self, previous_prime):
-    prime_candidate = previous_prime
-    while True:
-      prime_candidate += 2 # skip even numbers which cannot be primes
-      self._add_next_relevant_prime_multiple_if_needed(prime_candidate)
-      if not self._has_any_prime_divisor(prime_candidate):
-        return prime_candidate
+   def _find_next_prime(self, previous_prime):
+      prime_candidate = previous_prime
+      while True:
+         prime_candidate += 2 # skip even numbers which cannot be primes
+         self._add_next_relevant_prime_multiple_if_needed(prime_candidate)
+         if not self._has_any_prime_divisor(prime_candidate):
+            return prime_candidate
 
-  def _add_next_relevant_prime_multiple_if_needed(self, prime_candidate):
-    # If we're testing primality of N, we only need to test divisibility
-    # with primes up to sqrt(N)
-    m = len(self.prime_multiples)
-    prime = self.primes[m] if m < len(self.primes) else 0
-    if prime_candidate == prime**2:
-      self.prime_multiples.append(prime**2)
+   def _add_next_relevant_prime_multiple_if_needed(self, prime_candidate):
+      # If we're testing primality of N, we only need to test divisibility
+      # with primes up to sqrt(N)
+      m = len(self.prime_multiples)
+      prime = self.primes[m] if m < len(self.primes) else 0
+      if prime_candidate == prime**2:
+         self.prime_multiples.append(prime**2)
 
-  def _has_any_prime_divisor(self, odd_number):
-    return any(
-      self._is_divisible_by_nth_prime(odd_number, n)
-      # self.prime_multiples[0] (=2) is even, so we can skip its multiples
-      for n in range(1, len(self.prime_multiples))
-    )
+   def _has_any_prime_divisor(self, odd_number):
+      return any(
+         self._is_divisible_by_nth_prime(odd_number, n)
+         # self.prime_multiples[0] (=2) is even, so we can skip its multiples
+         for n in range(1, len(self.prime_multiples))
+      )
 
-  def _is_divisible_by_nth_prime(self, odd_number, n):
-    # This is the implementation of the first optimization described above.
-    # Notice that we don't ever need to reset `self.prime_multiples[n]`
-    # because during prime generation we test only increasingly larger numbers.
-    while self.prime_multiples[n] < odd_number:
-      # `self.prime_multiples[n] + self.prime[n]` is even so we can safely
-      # skip to the next multiple
-      self.prime_multiples[n] += self.primes[n] + self.primes[n]
-    return self.prime_multiples[n] == odd_number
+   def _is_divisible_by_nth_prime(self, odd_number, n):
+      # This is the implementation of the first optimization described above.
+      # Notice that we don't ever need to reset `self.prime_multiples[n]`
+      # because during prime generation we test only increasingly larger numbers.
+      while self.prime_multiples[n] < odd_number:
+         # `self.prime_multiples[n] + self.prime[n]` is even so we can safely
+         # skip to the next multiple
+         self.prime_multiples[n] += self.primes[n] + self.primes[n]
+      return self.prime_multiples[n] == odd_number
 
 def compute_primes(n):
-  return PrimeGenerator().generate(n)
+   return PrimeGenerator().generate(n)
 ```
 
 While I don't claim this version is "perfect"--the `_is_divisible_by_nth_prime` method still has a side-effect, and the explanation of the optimizations is not detailed enough--I do hope you can agree that this version is much easier to understand for a future reader.

--- a/content/blog/clean-code/index.md
+++ b/content/blog/clean-code/index.md
@@ -30,19 +30,19 @@ The following function determines if its argument is a valid IP address. Do you 
 
 ```python
 def isIPV4(txt):
-  ints = txt.split('.')
-  cnt = 0
-  for i in range(0, len(ints)):
-    try:
-      v = int(ints[i])
-      if v < 0 or v > 255:
-        return False
-    except Exception:
-      return False
-    cnt += 1
-  if cnt == 4:
-    return True
-  return False
+   ints = txt.split('.')
+   cnt = 0
+   for i in range(0, len(ints)):
+      try:
+         v = int(ints[i])
+         if v < 0 or v > 255:
+            return False
+      except Exception:
+         return False
+      cnt += 1
+   if cnt == 4:
+      return True
+   return False
 ```
 
 ### Idiomatic Code
@@ -53,19 +53,19 @@ Another issue is the use of non-standard abbreviations (e.g., `cnt`, `txt`), whi
 
 ```python
 def is_ipv4(text):
-  parts = text.split('.')
-  count = 0
-  for part in parts:
-    try:
-      v = int(part)
-      if v < 0 or v > 255:
-        return False
-    except Exception:
-      return False
-    count += 1
-  if count == 4:
-    return True
-  return False
+   parts = text.split('.')
+   count = 0
+   for part in parts:
+      try:
+         v = int(part)
+         if v < 0 or v > 255:
+            return False
+      except Exception:
+         return False
+      count += 1
+   if count == 4:
+      return True
+   return False
 ```
 
 Perhaps not much of a difference, but bear with me: the secret behind improving code in a reliable way (as Martin Fowler has described in his book [Refactoring](https://martinfowler.com/books/refactoring.html)) lies in making many small, almost trivial transformations.
@@ -78,20 +78,20 @@ In our example, we can see that happening inside the `for` loop: it's trying to 
 
 ```python
 def is_ipv4(text):
-  # split into octets and verify that there are exactly four
-  parts = text.split('.')
-  if len(parts) != 4:
-    return False
-
-  # verify that each octet is valid
-  for part in parts:
-    try:
-      v = int(part)
-      if v < 0 or v > 255:
-        return False
-    except Exception:
+   # split into octets and verify that there are exactly four
+   parts = text.split('.')
+   if len(parts) != 4:
       return False
-  return False
+
+   # verify that each octet is valid
+   for part in parts:
+      try:
+         v = int(part)
+         if v < 0 or v > 255:
+            return False
+      except Exception:
+         return False
+   return False
 ```
 
 We added some comments to organize our thoughts, but we should be able to get rid of them by writing code that is completely self-explanatory. In most cases, comments should be reserved to explain _why_ we implemented something in a certain way, not _what_ we did (redundant if we've picked good names) or _how_ we did it (redundant if our logic is simple and straightforward.)
@@ -112,29 +112,29 @@ If we try to restructure our code to follow this principle, we get the following
 
 ```python
 def is_ipv4(text):
-  parts = text.split('.')
-  if len(parts) != 4:
-    return False
-  return all(is_octet(part) for part in parts)
+   parts = text.split('.')
+   if len(parts) != 4:
+      return False
+   return all(is_octet(part) for part in parts)
 ```
 
 This code tells a shorter story and minimizes the details so we can focus on the big picture. This definitely is easier to grasp at a glance. We can even go one step further and simplify the code as follows:
 
 ```python
 def is_ipv4(text):
-  parts = text.split('.')
-  return len(parts) == 4 and all(is_octet(part) for part in parts)
+   parts = text.split('.')
+   return len(parts) == 4 and all(is_octet(part) for part in parts)
 ```
 
 This version reads almost like English prose and is quite easy to eyeball for logical errors. At this point, the implementation of `is_octet` should not really be that important (as long as it's correct), but let's add it for the sake of completeness:
 
 ```python
 def is_octet(part):
-  return part.isdigit() and 0 <= int(part) <= 255
+   return part.isdigit() and 0 <= int(part) <= 255
 
 def is_ipv4(text):
-  parts = text.split('.')
-  return len(parts) == 4 and all(is_octet(part) for part in parts)
+   parts = text.split('.')
+   return len(parts) == 4 and all(is_octet(part) for part in parts)
 ```
 
 Notice how we avoided using a `try/except` block and used a more idiomatic way to test if a value lies in a range, thus simplifying the definition of `is_octet` substantially.
@@ -143,11 +143,11 @@ Some programmers might complain that this practice can pollute the namespace wit
 
 ```python
 def is_ipv4(text):
-  def is_octet(part):
-    return part.isdigit() and 0 <= int(part) <= 255
+   def is_octet(part):
+      return part.isdigit() and 0 <= int(part) <= 255
 
-  parts = text.split('.')
-  return len(parts) == 4 and all(is_octet(part) for part in parts)
+   parts = text.split('.')
+   return len(parts) == 4 and all(is_octet(part) for part in parts)
 ```
 
 ## Conclusion

--- a/content/blog/dynamic-programming/index.md
+++ b/content/blog/dynamic-programming/index.md
@@ -28,7 +28,7 @@ We can translate this description into the following function definition and som
 
 ```python
 def can_segment(text: str, words: Set[str]) -> bool:
-  ...
+   ...
 
 assert can_segment("helloworld", {"hello", "world"}) == True
 assert can_segment("howareyou", {"are", "you", "how"}) == True
@@ -39,27 +39,27 @@ To solve this problem, think what happens if we take any word from the set and m
 
 ```python
 def can_segment(string, words):
-  def _find_word_prefixes(suffix):
-    for word in words:
-      if suffix.startswith(word):
-        yield word
+   def _find_word_prefixes(suffix):
+      for word in words:
+         if suffix.startswith(word):
+            yield word
 
-  def _can_segment(suffix):
-    if len(suffix) == 0:
-      return True
-    for match in _find_word_prefixes(suffix):
-      if _can_segment(suffix[len(match):]):
-        return True
-    return False
+   def _can_segment(suffix):
+      if len(suffix) == 0:
+         return True
+      for match in _find_word_prefixes(suffix):
+         if _can_segment(suffix[len(match):]):
+            return True
+      return False
 
-  return _can_segment(string)
+   return _can_segment(string)
 ```
 
 One problem with this solution is that it can end up calling `_can_segment` multiple times for the same argument. Let's see a concrete example to visualize how this could happen:
 
 ```python
 words = {
-  "the", "ban", "banana", "ana", "gave", "us", "is", "right"
+   "the", "ban", "banana", "ana", "gave", "us", "is", "right"
 }
 can_segment("thebananagaveusisfair", words)
 # one possible sequence of calls could be:
@@ -86,11 +86,11 @@ One way to fix this problem is to [memoize](https://en.wikipedia.org/wiki/Memoiz
 from functools import lru_cache
 
 def can_segment(string, words):
-  def _find_word_prefixes(text):
-    ...
-  @lru_cache(maxsize=len(string))
-  def _can_segment(suffix):
-    ...
+   def _find_word_prefixes(text):
+      ...
+   @lru_cache(maxsize=len(string))
+   def _can_segment(suffix):
+      ...
 ```
 
 Memoization works very well for [pure functions](https://en.wikipedia.org/wiki/Pure_function), but in our case the function is not completely pure because it depends on the dictionary of words. Despite that, we are able to make it work because --for the purposes of an individual call to the outer function `can_segment`-- `words` is immutable, so `_can_segment` can still be memoized properly.
@@ -109,38 +109,38 @@ First, we can avoid passing a string to the `_can_segment` function simply by pa
 
 ```python
 def can_segment(string, words):
-  def _find_word_prefixes(offset):
-    for word in words:
-      if string.startswith(word, offset):
-        yield word
+   def _find_word_prefixes(offset):
+      for word in words:
+         if string.startswith(word, offset):
+            yield word
 
-  @lru_cache(maxsize=len(string))
-  def _can_segment(offset):
-    if offset == len(string) - 1:
-      return True
-    for match in _find_word_prefixes(offset):
-      if _can_segment(offset + len(match)):
-        return True
-    return False
-    
-  return _can_segment(0)
+   @lru_cache(maxsize=len(string))
+   def _can_segment(offset):
+      if offset == len(string) - 1:
+         return True
+      for match in _find_word_prefixes(offset):
+         if _can_segment(offset + len(match)):
+            return True
+      return False
+
+   return _can_segment(0)
 ```
 
 Now that the function takes a single integer as input, it's easier to see a transformation to an iterative solution that indexes a table of intermediate results. This transformation will require an array of booleans that tells us, for each possible `offset`, whether there is a way to segment the corresponding suffix into words:
 
 ```python
 def can_segment_iterative(string, words):
-  n = len(string)
-  _can_segment = [False for _ in range(n + 1)]
-  _can_segment[n] = True
-  for offset in reversed(range(n)):
-    for word in words:
-      if not string.startswith(word, offset):
-        continue
-      _can_segment[offset] = _can_segment[offset + len(word)]
-      if _can_segment[offset]:
-        break
-  return _can_segment[0]
+   n = len(string)
+   _can_segment = [False for _ in range(n + 1)]
+   _can_segment[n] = True
+   for offset in reversed(range(n)):
+      for word in words:
+         if not string.startswith(word, offset):
+            continue
+         _can_segment[offset] = _can_segment[offset + len(word)]
+         if _can_segment[offset]:
+            break
+   return _can_segment[0]
 ```
 
 Notice how the fundamental computations are the same, but we had to restructure a few things to fit into the iterative style. One interesting thing to notice--which was harder to see in the recursive implementation--is that this procedure has time complexity $O(nw)$ where $n$ is the size of the string and $w$ is the number of words in the dictionary (assuming, of course, that most words are much smaller than the string we're trying to segment.)

--- a/content/blog/primes/index.md
+++ b/content/blog/primes/index.md
@@ -31,25 +31,25 @@ Here is a very simple (i.e., unoptimized) implementation of this algorithm in Py
 
 ```python
 def generate_primes_upto(n):
-  is_prime = [True] * (n + 1)
-  for candidate in range(2, n + 1):
-    if is_prime[candidate]:
-      cross_out_multiples_of(candidate, is_prime)
-  return collect_primes(is_prime)
+   is_prime = [True] * (n + 1)
+   for candidate in range(2, n + 1):
+      if is_prime[candidate]:
+         cross_out_multiples_of(candidate, is_prime)
+   return collect_primes(is_prime)
 
 def cross_out_multiples_of(prime, is_prime):
-  n = len(is_prime)
-  multiple = prime + prime
-  while multiple < n:
-    is_prime[multiple] = False
-    multiple += prime
+   n = len(is_prime)
+   multiple = prime + prime
+   while multiple < n:
+      is_prime[multiple] = False
+      multiple += prime
 
 def collect_primes(is_prime):
-  primes = []
-  for number in range(2, len(is_prime)):
-    if is_prime[number]:
-      primes.append(number)
-  return primes
+   primes = []
+   for number in range(2, len(is_prime)):
+      if is_prime[number]:
+         primes.append(number)
+   return primes
 ```
 
 A run of this algorithm with $N=31$ shows us that everything seems to be working as expected:[^test-properly]
@@ -92,19 +92,19 @@ Applying these optimizations results in updates to the `generate_primes_upto` an
 
 ```python
 def generate_primes_upto(n):
-  is_prime = [True] * (n + 1)
-  limit = math.floor(math.sqrt(n)) # highlight-line
-  for candidate in range(3, limit + 1, 2): # highlight-line
-    if is_prime[candidate]:
-      cross_out_multiples_of(candidate, is_prime)
-  return collect_primes(is_prime)
+   is_prime = [True] * (n + 1)
+   limit = math.floor(math.sqrt(n)) # highlight-line
+   for candidate in range(3, limit + 1, 2): # highlight-line
+      if is_prime[candidate]:
+         cross_out_multiples_of(candidate, is_prime)
+   return collect_primes(is_prime)
 
 def collect_primes(is_prime):
-  primes = [2] # highlight-line
-  for number in range(3, len(is_prime), 2): # highlight-line
-    if is_prime[number]:
-      primes.append(number)
-  return primes
+   primes = [2] # highlight-line
+   for number in range(3, len(is_prime), 2): # highlight-line
+      if is_prime[number]:
+         primes.append(number)
+   return primes
 ```
 
 We can run a quick ["smoke" test](<https://en.wikipedia.org/wiki/Smoke_testing_(software)>) to ensure we didn't totally break the algorithm:
@@ -184,11 +184,11 @@ This changes the `cross_out_multiples_of` function as follows:
 
 ```python
 def cross_out_multiples_of(prime, is_prime):
-  n = len(is_prime)
-  multiple = prime**2 # highlight-line
-  while multiple < n:
-    is_prime[multiple] = False
-    multiple += 2*prime # highlight-line
+   n = len(is_prime)
+   multiple = prime**2 # highlight-line
+   while multiple < n:
+      is_prime[multiple] = False
+      multiple += 2*prime # highlight-line
 ```
 
 ## Primes Ad Infinitum
@@ -237,84 +237,84 @@ With a strong grasp of these ideas, we can finally present an implementation tha
 from itertools import count
 
 class PrimeGenerator:
-  def generate(self):
-    self.primes = [2, 3]
-    self.prime_divisors = PrimeDivisors(self.primes)
+   def generate(self):
+      self.primes = [2, 3]
+      self.prime_divisors = PrimeDivisors(self.primes)
 
-    yield from self.primes
-    while True:
-      self.primes.append(self._next_prime())
-      yield self.primes[-1]
+      yield from self.primes
+      while True:
+         self.primes.append(self._next_prime())
+         yield self.primes[-1]
 
-  def _next_prime(self):
-    # step=2 to avoid redundant tests of even numbers
-    for candidate in count(self.primes[-1] + 2, step=2):
-      self._add_new_prime_divisor_if_needed(candidate)
-      if not self.prime_divisors.has_divisor_for(candidate):
-        return candidate
+   def _next_prime(self):
+      # step=2 to avoid redundant tests of even numbers
+      for candidate in count(self.primes[-1] + 2, step=2):
+         self._add_new_prime_divisor_if_needed(candidate)
+         if not self.prime_divisors.has_divisor_for(candidate):
+            return candidate
 
-  def _add_new_prime_divisor_if_needed(self, candidate):
-    m = len(self.prime_divisors) - 1
-    prime = self.primes[m]
-    if candidate == prime**2:
-      self.prime_divisors.add(prime)
+   def _add_new_prime_divisor_if_needed(self, candidate):
+      m = len(self.prime_divisors) - 1
+      prime = self.primes[m]
+      if candidate == prime**2:
+         self.prime_divisors.add(prime)
 ```
 
 ```python
 class PrimeDivisors:
-  def __init__(self, first_primes):
-    # 2 => 4, 6, 8, 10, 12, 14, 16, ...
-    # 3 => 9, 15, 21, 27, 33, ...
-    # ...
-    self.multiples_of_nth_prime = [
-      PrimeMultiples(prime) for prime in first_primes
-    ]
+   def __init__(self, first_primes):
+      # 2 => 4, 6, 8, 10, 12, 14, 16, ...
+      # 3 => 9, 15, 21, 27, 33, ...
+      # ...
+      self.multiples_of_nth_prime = [
+         PrimeMultiples(prime) for prime in first_primes
+      ]
 
-  def add(self, prime):
-    self.multiples_of_nth_prime.append(PrimeMultiples(prime))
+   def add(self, prime):
+      self.multiples_of_nth_prime.append(PrimeMultiples(prime))
 
-  def has_divisor_for(self, prime_candidate):
-    return any(
-      self.is_divisible_by_nth_prime(prime_candidate, n)
-      for n in range(len(self.multiples_of_nth_prime))
-    )
+   def has_divisor_for(self, prime_candidate):
+      return any(
+         self.is_divisible_by_nth_prime(prime_candidate, n)
+         for n in range(len(self.multiples_of_nth_prime))
+      )
 
-  def is_divisible_by_nth_prime(self, candidate, n):
-    # candidate % n == 0 is equivalent to implicitly checking 
-    # that remainder == 0 in prime + ... + remainder == candidate
-    while self.multiples_of_nth_prime[n].head < candidate:
-      next(self.multiples_of_nth_prime[n])
-    return self.multiples_of_nth_prime[n].head == candidate
+   def is_divisible_by_nth_prime(self, candidate, n):
+      # candidate % n == 0 is equivalent to implicitly checking
+      # that remainder == 0 in prime + ... + remainder == candidate
+      while self.multiples_of_nth_prime[n].head < candidate:
+         next(self.multiples_of_nth_prime[n])
+      return self.multiples_of_nth_prime[n].head == candidate
 
-  def __len__(self):
-    return len(self.multiples_of_nth_prime)
+   def __len__(self):
+      return len(self.multiples_of_nth_prime)
 ```
 
 ```python
 class PrimeMultiples:
-  def __init__(self, prime):
-    self.prime = prime
-    # NOTE(optimization): multiples below `prime^2` are covered 
-    # by smaller primes
-    self.head = self.prime**2
+   def __init__(self, prime):
+      self.prime = prime
+      # NOTE(optimization): multiples below `prime^2` are covered
+      # by smaller primes
+      self.head = self.prime**2
 
-  def __iter__(self):
-    return PrimeMultiples(self.prime)
+   def __iter__(self):
+      return PrimeMultiples(self.prime)
 
-  def __next__(self):
-    result = self.head
-    self.head += 2*self.prime
-    return result
+   def __next__(self):
+      result = self.head
+      self.head += 2*self.prime
+      return result
 ```
 
 To test this implementation, we will need a couple of helper functions:
 
 ```python
 def take_upto(limit, iterable):
-  return list(takewhile(lambda x: x <= limit, iterable))
+   return list(takewhile(lambda x: x <= limit, iterable))
 
 def generate_primes_upto_incremental(limit):
-  return take_upto(limit, PrimeGenerator().generate())
+   return take_upto(limit, PrimeGenerator().generate())
 ```
 
 We can then verify that it produces the same result as the original sieve:

--- a/content/blog/recursion/index.md
+++ b/content/blog/recursion/index.md
@@ -8,30 +8,30 @@ Courses introducing the topic of "recursion" for the first time have fallen into
 
 ```python
 def factorial(n):
-  if n == 0:
-    return 1
-  return n * factorial(n-1)
+   if n == 0:
+      return 1
+   return n * factorial(n-1)
 
 def fibonacci(n):
-  if n == 0 or n == 1:
-    return n
-  return fibonacci(n-1) * fibonacci(n-2)
+   if n == 0 or n == 1:
+      return n
+   return fibonacci(n-1) * fibonacci(n-2)
 ```
 
 The reason why these are silly examples is that they are totally impractical to be used in the real world, as both of them are unnecessarily inefficient (exponentially inefficient in the case of `fibonacci`!), while their iterative versions are easier to grasp and much more efficient:
 
 ```python
 def factorial(n):
-  product = 1
-  for i in range(1, n+1):
-    product *= i
-  return product
+   product = 1
+   for i in range(1, n+1):
+      product *= i
+   return product
 
 def fibonacci(n):
-  a, b = 0, 1
-  for _ in range(n):
-    a, b = b, a + b
-  return a
+   a, b = 0, 1
+   for _ in range(n):
+      a, b = b, a + b
+   return a
 ```
 
 Though I know this is done for pedagogical reasons (i.e., to avoid cognitive overload), I believe that students often leave such courses feeling like recursion is just another one of those confusing and complicated techniques that they'll never use in the real world, which is a sad thing because recursion can be a very powerful programming technique when it's properly explained and contextualized.
@@ -76,27 +76,27 @@ And so, if we assume some representation for simple algebraic expressions, we ca
 
 ```python
 def differentiate(expression, variable):
-  e = expression # highlight-line
-  if e.is_number: # highlight-line
-    return Number(0) # highlight-line
+   e = expression # highlight-line
+   if e.is_number: # highlight-line
+      return Number(0) # highlight-line
 
-  if e.is_variable: # highlight-line
-    if e == variable: # highlight-line
-      return Number(1) # highlight-line
-    return Number(0) # highlight-line
+   if e.is_variable: # highlight-line
+      if e == variable: # highlight-line
+         return Number(1) # highlight-line
+      return Number(0) # highlight-line
 
-  if e.is_sum:
-    return (
-      differentiate(e.augend, variable)
-      + differentiate(e.addend, variable)
-    )
+   if e.is_sum:
+      return (
+         differentiate(e.augend, variable)
+         + differentiate(e.addend, variable)
+      )
 
-  if e.is_product:
-    return (
-      differentiate(e.multiplicand, var) * e.multiplier
-      + differentiate(e.multiplier, var) * e.multiplicand
-    )
-  raise ValueError(f"{e} is not a supported expression!")
+   if e.is_product:
+      return (
+         differentiate(e.multiplicand, var) * e.multiplier
+         + differentiate(e.multiplier, var) * e.multiplicand
+      )
+   raise ValueError(f"{e} is not a supported expression!")
 ```
 
 As long as the input expression `expression` is built out of simpler expressions (eventually reaching constants or single variables), the above function will behave correctly since the base cases are handled properly in the highlighted lines, and the recursive cases always solve a smaller instance of the original problem.
@@ -111,37 +111,37 @@ For the above code to work, it is necessary to define some classes that implemen
 
 ```python
 class Expression:
-  @property
-  def is_number(self):
-    return False
+   @property
+   def is_number(self):
+      return False
 
-  @property
-  def is_variable(self):
-    return False
-  ...
+   @property
+   def is_variable(self):
+      return False
+   ...
 
 class Number(Expression):
-  def __init__(self, value):
-    self.value = value
+   def __init__(self, value):
+      self.value = value
 
-  @property
-  def is_number(self):
-    return True
+   @property
+   def is_number(self):
+      return True
 
-  def __eq__(self, rhs):
-    rhs = implicit_cast(rhs)
-    if not rhs.is_number:
-      return False
-    return self.value == rhs.value
+   def __eq__(self, rhs):
+      rhs = implicit_cast(rhs)
+      if not rhs.is_number:
+         return False
+      return self.value == rhs.value
 
-  def __add__(self, rhs):
-    if self.value == 0:
-      return rhs
-    rhs = implicit_cast(rhs)
-    if rhs.is_number:
-      return Number(self.value + rhs.value)
-    return Sum(self, rhs)
-  ...
+   def __add__(self, rhs):
+      if self.value == 0:
+         return rhs
+      rhs = implicit_cast(rhs)
+      if rhs.is_number:
+         return Number(self.value + rhs.value)
+      return Sum(self, rhs)
+   ...
 ```
 
 If you're interested in seeing this in action and studying the whole code in detail, you can clone [this repository](https://github.com/zxul767/pyexpr/) and play with the implementation (e.g., check out and run the code in `tests`).
@@ -154,13 +154,13 @@ from src.expression import Variable
 
 @pytest.fixture
 def x():
-  return Variable("x")
+   return Variable("x")
 
 def test__can_differentiate_sums_and_products_recursively(x):
-  result = differentiate((2 * x * x) + x * (x + 1), x)
+   result = differentiate((2 * x * x) + x * (x + 1), x)
 
-  # TODO: implement simplification of expressions
-  assert result == (2 * x + 2 * x) + (1 + x + x)
+   # TODO: implement simplification of expressions
+   assert result == (2 * x + 2 * x) + (1 + x + x)
 ```
 
 ## Conclusion

--- a/content/blog/swe-fundamental-skill/index.md
+++ b/content/blog/swe-fundamental-skill/index.md
@@ -58,20 +58,20 @@ The [first link](https://tour.golang.org/concurrency/1) is a better example whic
 package main
 
 import (
-  "fmt"
-  "time"
+   "fmt"
+   "time"
 )
 
 func say(s string) {
-  for i := 0; i < 5; i++ {
-    time.Sleep(100 * time.Millisecond)
-    fmt.Println(s)
-  }
+   for i := 0; i < 5; i++ {
+      time.Sleep(100 * time.Millisecond)
+      fmt.Println(s)
+   }
 }
 
 func main() {
-  go say("world")
-  say("hello")
+   go say("world")
+   say("hello")
 }
 ```
 
@@ -87,23 +87,23 @@ In the `goroutines` sample code above, I might be curious to understand how mult
 package main
 
 import (
-  "fmt"
-  "time"
+   "fmt"
+   "time"
 )
 
 func fn(from string) {
-  for i := 0; i < 3; i++ {
-    fmt.Println(from, ":", i)
-  }
+   for i := 0; i < 3; i++ {
+      fmt.Println(from, ":", i)
+   }
 }
 
 func main() {
-  for i := 0; i < 5; i++ {
-    go fn(fmt.Sprintf("iteration: %d, goroutine 1", i))
-    go fn(fmt.Sprintf("iteration: %d, goroutine 2", i))
-    time.Sleep(time.Millisecond * 50)
-  }
-  fmt.Println("done")
+   for i := 0; i < 5; i++ {
+      go fn(fmt.Sprintf("iteration: %d, goroutine 1", i))
+      go fn(fmt.Sprintf("iteration: %d, goroutine 2", i))
+      time.Sleep(time.Millisecond * 50)
+   }
+   fmt.Println("done")
 }
 ```
 

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,8 +1,5 @@
 // math equations
 import "katex/dist/katex.min.css"
 
-// code blocks
-import "gatsby-remark-vscode/styles.css"
-
 // other customizations
 import "./src/styles/global.css"

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -42,13 +42,9 @@ module.exports = {
             },
           },
           {
-            resolve: `gatsby-remark-vscode`,
+            resolve: `${__dirname}/plugins/remark-shiki`,
             options: {
-              theme: "azure-light",
-              extensions: ["common-lisp", "rainglow"],
-              inlineCode: {
-                marker: "•",
-              },
+              theme: "rose-pine-dawn",
             },
           },
           `gatsby-remark-copy-linked-files`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "common-lisp": "github:qingpeng9802/vscode-common-lisp",
         "gatsby": "^5.16.1",
         "gatsby-plugin-manifest": "^5.16.0",
         "gatsby-plugin-page-progress": "^2.2.1",
@@ -21,17 +20,16 @@
         "gatsby-remark-katex": "^7.16.0",
         "gatsby-remark-numbered-footnotes": "^1.0.1",
         "gatsby-remark-smartypants": "^6.16.0",
-        "gatsby-remark-vscode": "^3.3.1",
         "gatsby-source-filesystem": "^5.16.0",
         "gatsby-transformer-remark": "^6.16.0",
         "gatsby-transformer-sharp": "^5.16.0",
         "katex": "^0.13.10",
         "prop-types": "^15.7.2",
-        "rainglow": "github:webrgp/vscode#patch-1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-social-icons": "^5.6.1",
         "react-typography": "^0.16.23",
+        "shiki": "^4.4.1",
         "typography": "^0.16.24",
         "typography-theme-moraga": "^0.16.19"
       },
@@ -4120,6 +4118,395 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "license": "MIT"
     },
+    "node_modules/@shikijs/core": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.4.1.tgz",
+      "integrity": "sha512-VeR2CY6Nn9/WbisoYLOQZ7HZOnwTrpBuOw4wExjqLnBCi62BNWynBUO6K2uPIASPFJwAv7cX1fUu+LrPlSstcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.4.1",
+        "@shikijs/types": "4.4.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@shikijs/core/node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.4.1.tgz",
+      "integrity": "sha512-6U4lJBh8LTvIkEVqRHv/rr3ruwtO6IweFQt1ME1ntHJMGHS+6N86vfYGO1o8c/DtOCTia2lfhdQBtBrps1sDfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.1.tgz",
+      "integrity": "sha512-p23RugMKss0r5DAtRJW1yAXUDl60JvhQYV20yuxei//26JyDSJefV3umyWzzwep2weblMnJGDYahuti6XkcMgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.1",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.4.1.tgz",
+      "integrity": "sha512-xb2kCMloBCIraIy2fS5MW0t/BxVY3q2nDyQKBoeSeq6KNrQbShHetCFlw2n35fGIJ6t3+hXDLQogP5ir9O9bvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.4.1.tgz",
+      "integrity": "sha512-ko2OfDoG89YuQ7xL5LtcQiWKb7NIv1Ephb7g48TVU198OzAMLC8lXVEwaJGHK4sUMYrfAGJDqYmNLOLiW/Kz8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.4.1.tgz",
+      "integrity": "sha512-wudOaoFro+/Zl9gQv2W1Ur5XlVduqvTuYLI483Xi0wgc1A+cy1hfB2r6ac6ufBgF+ID7KJEW7L41MHrzQ4wH+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.4.1.tgz",
+      "integrity": "sha512-GOwCLQDHM5EjGUWNPrhzJbr6JP8V/Dx/CDVkWvbZ1Avw5JFnNUckrgbLmE07qtg4WlW7Q7QFndhjIkeU9XMPvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -4957,6 +5344,12 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
+    },
     "node_modules/@vercel/webpack-asset-relocator-loader": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.7.3.tgz",
@@ -5110,15 +5503,6 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.6"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -6225,52 +6609,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/bl": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
-      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "node_modules/bl/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/bl/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/bl/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -6416,37 +6754,6 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
-    },
-    "node_modules/buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "node_modules/buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "license": "MIT"
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
-      "license": "MIT"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -7197,14 +7504,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/common-lisp": {
-      "version": "1.3.2",
-      "resolved": "git+ssh://git@github.com/qingpeng9802/vscode-common-lisp.git#ad508f15ae8dd0070e6ec9397908499012551e7b",
-      "license": "MIT",
-      "engines": {
-        "vscode": "^1.63.0"
-      }
-    },
     "node_modules/common-tags": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -7446,12 +7745,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -7943,25 +8236,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/decompress": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
-      "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "decompress-tar": "^4.0.0",
-        "decompress-tarbz2": "^4.0.0",
-        "decompress-targz": "^4.0.0",
-        "decompress-unzip": "^4.0.1",
-        "graceful-fs": "^4.1.10",
-        "make-dir": "^1.0.0",
-        "pify": "^2.3.0",
-        "strip-dirs": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -7987,162 +8261,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decompress-tar": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
-      "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-type": "^5.2.0",
-        "is-stream": "^1.1.0",
-        "tar-stream": "^1.5.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-tar/node_modules/file-type": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-      "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-tar/node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decompress-tarbz2": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
-      "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
-      "license": "MIT",
-      "dependencies": {
-        "decompress-tar": "^4.1.0",
-        "file-type": "^6.1.0",
-        "is-stream": "^1.1.0",
-        "seek-bzip": "^1.0.5",
-        "unbzip2-stream": "^1.0.9"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-tarbz2/node_modules/file-type": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-      "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-tarbz2/node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decompress-targz": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
-      "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
-      "license": "MIT",
-      "dependencies": {
-        "decompress-tar": "^4.1.1",
-        "file-type": "^5.2.0",
-        "is-stream": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-targz/node_modules/file-type": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-      "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-targz/node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decompress-unzip": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
-      "integrity": "sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==",
-      "license": "MIT",
-      "dependencies": {
-        "file-type": "^3.8.0",
-        "get-stream": "^2.2.0",
-        "pify": "^2.3.0",
-        "yauzl": "^2.4.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-unzip/node_modules/file-type": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-      "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decompress-unzip/node_modules/get-stream": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-      "integrity": "sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4.0.1",
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decompress/node_modules/make-dir": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress/node_modules/make-dir/node_modules/pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/deep-extend": {
@@ -8248,6 +8366,15 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -8318,6 +8445,19 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -9971,15 +10111,6 @@
       "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
       "license": "MIT"
     },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -11134,45 +11265,6 @@
       },
       "peerDependencies": {
         "gatsby": "^5.0.0-next"
-      }
-    },
-    "node_modules/gatsby-remark-vscode": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-vscode/-/gatsby-remark-vscode-3.3.1.tgz",
-      "integrity": "sha512-KUCDU8KauLikURYuGyAZ0aLhHhd/BP2XwzP/WP0wkgyKjh650PwewQghwpD9g2wVkN+fThFJDs4G64K4fduDGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "decompress": "^4.2.0",
-        "json5": "^2.1.1",
-        "loglevel": "^1.6.4",
-        "plist": "^3.0.1",
-        "unist-util-visit": "^1.4.1",
-        "vscode-oniguruma": "^1.4.0",
-        "vscode-textmate": "^5.2.0"
-      }
-    },
-    "node_modules/gatsby-remark-vscode/node_modules/unist-util-is": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
-      "license": "MIT"
-    },
-    "node_modules/gatsby-remark-vscode/node_modules/unist-util-visit": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit-parents": "^2.0.0"
-      }
-    },
-    "node_modules/gatsby-remark-vscode/node_modules/unist-util-visit-parents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-is": "^3.0.0"
       }
     },
     "node_modules/gatsby-script": {
@@ -12986,12 +13078,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-natural-number": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
-      "integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==",
-      "license": "MIT"
-    },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -13776,19 +13862,6 @@
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
     },
-    "node_modules/loglevel": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
-      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/loglevel"
-      }
-    },
     "node_modules/longest-streak": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
@@ -14379,6 +14452,95 @@
       "bin": {
         "katex": "cli.js"
       }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -15211,6 +15373,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/open": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
@@ -15818,12 +15997,6 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "license": "MIT"
-    },
     "node_modules/physical-cpu-count": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/physical-cpu-count/-/physical-cpu-count-2.0.0.tgz",
@@ -15846,36 +16019,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
-      "license": "MIT",
-      "dependencies": {
-        "pinkie": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -15968,20 +16111,6 @@
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "license": "MIT"
-    },
-    "node_modules/plist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
-      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
-      "license": "MIT",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.9.10",
-        "base64-js": "^1.5.1",
-        "xmlbuilder": "^15.1.1"
-      },
-      "engines": {
-        "node": ">=10.4.0"
-      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -16712,12 +16841,6 @@
         "node": ">= 0.6.0"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
-    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -16901,14 +17024,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/rainglow": {
-      "version": "1.5.2",
-      "resolved": "git+ssh://git@github.com/webrgp/vscode.git#5d400192102c861ece9f244cb69376b8a509ca3c",
-      "license": "MIT",
-      "engines": {
-        "vscode": "^1.13.0"
       }
     },
     "node_modules/randombytes": {
@@ -17387,6 +17502,30 @@
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
@@ -18265,25 +18404,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/seek-bzip": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
-      "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^2.8.1"
-      },
-      "bin": {
-        "seek-bunzip": "bin/seek-bunzip",
-        "seek-table": "bin/seek-bzip-table"
-      }
-    },
-    "node_modules/seek-bzip/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -18533,6 +18653,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.4.1.tgz",
+      "integrity": "sha512-rFP+iYKzjLEIqiMiKANhARqiAbk4deDhWnBtnUO/K0D0dPxMGDH4N0FVfBY/VeI+lPrV4wNGCHQZp7EOr7NNBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.4.1",
+        "@shikijs/engine-javascript": "4.4.1",
+        "@shikijs/engine-oniguruma": "4.4.1",
+        "@shikijs/langs": "4.4.1",
+        "@shikijs/themes": "4.4.1",
+        "@shikijs/types": "4.4.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/shiki/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/side-channel": {
@@ -19161,15 +19309,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/strip-dirs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
-      "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
-      "license": "MIT",
-      "dependencies": {
-        "is-natural-number": "^4.0.1"
-      }
-    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -19526,60 +19665,6 @@
         "streamx": "^2.15.0"
       }
     },
-    "node_modules/tar-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.2.0",
-        "end-of-stream": "^1.0.0",
-        "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.1",
-        "xtend": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/tar-stream/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
-    "node_modules/tar-stream/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/tar-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/tar-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/teex": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
@@ -19768,20 +19853,6 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/to-buffer": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
-      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "^2.0.5",
-        "safe-buffer": "^5.2.1",
-        "typed-array-buffer": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -19825,6 +19896,16 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/trim-repeated": {
       "version": "1.0.0",
@@ -20200,16 +20281,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/unbzip2-stream": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.2.1",
-        "through": "^2.3.8"
       }
     },
     "node_modules/unc-path-regex": {
@@ -20718,18 +20789,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/vscode-oniguruma": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-      "license": "MIT"
-    },
-    "node_modules/vscode-textmate": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.5.0.tgz",
-      "integrity": "sha512-jToQkPGMNKn0eyKyitYeINJF0NoD240aYyKPIWJv5W2jfPt++jIRg0OSergubtGhbw6SoefkvBYEpX7TsfoSUQ==",
-      "license": "MIT"
-    },
     "node_modules/watchpack": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
@@ -21095,15 +21154,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/xmlbuilder": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
-      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
@@ -21229,16 +21279,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "prettier": "^2.2.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=24"
       }
     },
     "node_modules/@ardatan/relay-compiler": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prod:lan": "gatsby serve -H 0.0.0.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=24"
   },
   "engineStrict": true
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "url": "https://github.com/zxul767/ex-machina/issues"
   },
   "dependencies": {
-    "common-lisp": "github:qingpeng9802/vscode-common-lisp",
     "gatsby": "^5.16.1",
     "gatsby-plugin-manifest": "^5.16.0",
     "gatsby-plugin-page-progress": "^2.2.1",
@@ -20,17 +19,16 @@
     "gatsby-remark-katex": "^7.16.0",
     "gatsby-remark-numbered-footnotes": "^1.0.1",
     "gatsby-remark-smartypants": "^6.16.0",
-    "gatsby-remark-vscode": "^3.3.1",
     "gatsby-source-filesystem": "^5.16.0",
     "gatsby-transformer-remark": "^6.16.0",
     "gatsby-transformer-sharp": "^5.16.0",
     "katex": "^0.13.10",
     "prop-types": "^15.7.2",
-    "rainglow": "github:webrgp/vscode#patch-1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-social-icons": "^5.6.1",
     "react-typography": "^0.16.23",
+    "shiki": "^4.4.1",
     "typography": "^0.16.24",
     "typography-theme-moraga": "^0.16.19"
   },

--- a/plugins/remark-shiki/index.js
+++ b/plugins/remark-shiki/index.js
@@ -1,0 +1,94 @@
+const fs = require("fs")
+const path = require("path")
+const visit = require("unist-util-visit")
+
+const DEFAULT_THEME = "github-light"
+
+const languageAliases = {
+  bash: "shellscript",
+  lisp: "common-lisp",
+  shell: "shellscript",
+}
+
+const highlightLineMarker =
+  /\s*(?:#|\/\/|;|<!--)\s*highlight-line\s*(?:-->)?\s*$/
+
+function loadBundledJson(packageName, moduleName) {
+  const packageDirectory = path.dirname(require.resolve(packageName))
+  const modulePath = path.join(packageDirectory, `${moduleName}.mjs`)
+  const source = fs.readFileSync(modulePath, "utf8")
+  const match = source.match(/JSON\.parse\(("(?:\\.|[^"\\])*")\)/)
+
+  if (!match) {
+    throw new Error(`Could not load Shiki module: ${modulePath}`)
+  }
+
+  return JSON.parse(JSON.parse(match[1]))
+}
+
+const highlighterPromises = new Map()
+
+function getHighlighter(theme) {
+  if (!highlighterPromises.has(theme)) {
+    highlighterPromises.set(
+      theme,
+      import("shiki").then(
+      ({ createHighlighterCoreSync, createJavaScriptRegexEngine }) =>
+        createHighlighterCoreSync({
+          engine: createJavaScriptRegexEngine(),
+          themes: [loadBundledJson("@shikijs/themes", theme)],
+          langs: [
+            loadBundledJson("@shikijs/langs", "common-lisp"),
+            loadBundledJson("@shikijs/langs", "shellscript"),
+            loadBundledJson("@shikijs/langs", "python"),
+            loadBundledJson("@shikijs/langs", "java"),
+            loadBundledJson("@shikijs/langs", "go"),
+          ],
+        })
+      )
+    )
+  }
+
+  return highlighterPromises.get(theme)
+}
+
+module.exports = async function remarkShiki({ markdownAST }, options = {}) {
+  const theme = options.theme || DEFAULT_THEME
+  const highlighter = await getHighlighter(theme)
+
+  visit(markdownAST, "code", (node) => {
+    const requestedLanguage = node.lang || "text"
+    const language = languageAliases[requestedLanguage] || requestedLanguage
+    const lang = highlighter.getLoadedLanguages().includes(language)
+      ? language
+      : "text"
+
+    const highlightLines = new Set()
+    const source = node.value
+      .split("\n")
+      .map((line, index) => {
+        if (highlightLineMarker.test(line)) {
+          highlightLines.add(index + 1)
+          return line.replace(highlightLineMarker, "")
+        }
+        return line
+      })
+      .join("\n")
+
+    let html = highlighter.codeToHtml(source, {
+      lang,
+      theme,
+    })
+
+    let lineNumber = 0
+    html = html.replace(/<span class="line">/g, (match) => {
+      lineNumber += 1
+      return highlightLines.has(lineNumber)
+        ? '<span class="line highlighted">'
+        : match
+    })
+
+    node.type = "html"
+    node.value = html
+  })
+}

--- a/plugins/remark-shiki/package.json
+++ b/plugins/remark-shiki/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "remark-shiki-local",
+  "private": true,
+  "main": "index.js"
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -19,12 +19,15 @@
   --figcaption-font-size: 0.9rem;
   --footer-font-size: 0.9rem;
 
-  --code-font-size: 0.85rem;
-  --code-font-family: "JetBrains Mono", Consolas, Liberation Mono, monospace;
+  --code-font-size: 0.9rem;
+  --code-font-family: "Inconsolata", Consolas, Liberation Mono, monospace;
+  --code-block-background: #faf4ed;
+  --code-block-foreground: #575279;
+  --code-highlighted-background: rgba(255, 128, 0, 0.1);
 }
 
 /* --------------------------------------------------------------------------*/
-/* VSCode Block Highlighting Customizations                                  */
+/* Shiki code block customizations                                            */
 /* --------------------------------------------------------------------------*/
 code,
 kbd,
@@ -33,18 +36,29 @@ samp {
   font-family: var(--code-font-family);
   font-size: var(--code-font-size);
 }
-pre.grvsc-container {
+code {
+  color: var(--code-block-foreground);
+  background-color: var(--code-block-background);
+  font-size: var(--code-font-size);
+  border-radius: 0.2rem;
+  padding: 0.1em 0.3em;
+}
+pre.shiki {
   border: 1px dashed;
   box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 6px -1px,
     rgba(0, 0, 0, 0.06) 0px 2px 4px -1px;
 }
-code.grvsc-code {
-  /* the default line spacing is too tall */
+pre.shiki code {
+  background-color: transparent;
+  border-radius: 0;
   line-height: 1.15rem;
-  /* ensure that highlighted lines cover the whole code block horizontally */
   width: 100%;
+  display: block;
+  overflow-x: auto;
+  padding: var(--spacing-small);
 }
-span.grvsc-source {
-  /* the default padding steals too much valuable display space for code */
-  padding-left: var(--spacing-compact);
+pre.shiki .line.highlighted {
+  display: inline-block;
+  width: 100%;
+  background-color: var(--code-highlighted-background);
 }

--- a/src/utils/typography.js
+++ b/src/utils/typography.js
@@ -8,7 +8,7 @@ moragaTheme.googleFonts = [
     styles: ["200", "400"],
   },
   {
-    name: "JetBrains Mono",
+    name: "Inconsolata",
     styles: ["400"],
   },
 ]


### PR DESCRIPTION
Done in this PR:
  - Replaced `gatsby-remark-vscode` with a local Shiki plugin that provides all features used in the blog.
  - Removed the vulnerable `common-lisp`, `rainglow`, and `gatsby-remark-vscode` dependencies.
  - Added configurable Shiki themes; current theme is rose-pine-dawn.
  - Changed the code font to Inconsolata.
  - Converted most Markdown fenced-code indentation to three spaces (except for Common Lisp, where indentation is a bit more nuanced)
  - Raised the project engine requirement to Node 24.
  - Removed the old VS Code highlighter stylesheet.

Limitations found:
  - Gatsby’s bundled `react-server-dom-webpack` causes peer-dependency warnings even in otherwise healthy Gatsby projects.
  - Gatsby 5.16.1 and its official plugins are already the latest available versions in this dependency range.
  - The audit still reports approximately 50 vulnerabilities: 9 low, 19 moderate, and 22 high, with no critical issues after removing the old
    highlighter.

  - Most remaining vulnerabilities come from Gatsby’s transitive GraphQL, Parcel, Webpack, Sharp, and CLI dependencies.
  - Updating React alone would not fix Gatsby’s peer warning.
  - Upgrading KaTeX independently conflicts with `gatsby-remark-katex`’s declared peer range.
  - Image loading remains unresolved and needs separate investigation.
  - The local Shiki plugin contains custom ESM-loading and bundled-theme parsing logic, which adds maintenance complexity.
  - No migration away from Gatsby has been attempted yet.
